### PR TITLE
fix: asociacion, podcast, and blog issues

### DIFF
--- a/src/components/blog/sidebar.css
+++ b/src/components/blog/sidebar.css
@@ -59,13 +59,14 @@
  * Permite expandir la lista de tags (funcionalidad futura)
  */
 .ver-todas-btn {
+  font-family: var(--font-title);
   font-size: 0.875rem; /* 14px */
+  line-height: 1;
   color: var(--font-color);
   background: none;
-  border: var(--font-color) 1px solid;
+  border: 2px solid var(--font-color);
   cursor: pointer;
-  padding: 0.1rem 0.4rem;
-  padding-top: 0.3rem;
+  padding: 0.6rem 0.9rem;
   border-radius: 0.2rem;
   transition: all 0.2s; /* Transición suave para hover */
 }

--- a/src/components/cave/cave.css
+++ b/src/components/cave/cave.css
@@ -53,6 +53,13 @@ div.cave-outside-wrapper img{
     width: fit-content; /* Ensure .cave-text wraps its content */
 }
 
+/* Light mode only: match the whitish tone of the outermost cave layer
+   (OUT-light.svg is #fbf7f4, i.e. --primary-color1) instead of the
+   dark-orange --primary-color4. Dark mode keeps --primary-color4. */
+html:not(.dark) .cave-text {
+    color: var(--primary-color1);
+}
+
 .cave-tittle {
     /* Font */
     font-family: "Roboto", sans-serif;

--- a/src/components/common/daterangepicker.css
+++ b/src/components/common/daterangepicker.css
@@ -41,6 +41,21 @@
 .date-picker input[type="date"] {
   background: transparent;
   border: none;
-  border-bottom: 1.5px solid #ffff;
-  color: #ffff;
+  border-bottom: 1.5px solid var(--font-color);
+  color: var(--font-color);
+}
+
+.date-picker svg {
+  stroke: var(--font-color);
+}
+
+/* The native date-input calendar icon is a fixed dark glyph that
+   doesn't respond to `color` - invert it in dark mode so it stays
+   visible against the dark background. */
+.date-picker input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: invert(0);
+}
+
+html.dark .date-picker input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: invert(1);
 }

--- a/src/components/members/memberCard.tsx
+++ b/src/components/members/memberCard.tsx
@@ -14,6 +14,7 @@ export const MemberCard = ({member}: MemberCardProps) => {
       </div>
       <div className="member-info">
         <h3 className="member-name">{member.name}</h3>
+        {member.cargo && <p className="member-cargo">{member.cargo}</p>}
         <p className="member-description">{member.description}</p>
       </div>
     </div>

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -34,7 +34,15 @@ const NavBar = ({ isLandingPage, centerComponent }: NavBarProps) => {
 
   // Listener para teclas
   useEffect(() => {
+    const isTypingTarget = (target: EventTarget | null) => {
+      const el = target as HTMLElement | null;
+      if (!el) return false;
+      const tag = el.tagName;
+      return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable;
+    };
+
     const handleKeyPress = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target)) return;
       const key = e.key.toLowerCase();
       if (key === 'b') navigate('/blogs');
       else if (key === 'p') navigate('/podcast');

--- a/src/components/podcast/podcastCard.tsx
+++ b/src/components/podcast/podcastCard.tsx
@@ -9,27 +9,33 @@ const PodcastCard = ({ podcastEpisode }: PodcastCardProps) => {
   return (
     <div key={podcastEpisode.id} className="podcast-card">
       <div className="podcast-video">
-        <iframe
-          width="100%"
-          height="200"
-          src={`https://www.youtube.com/embed/${podcastEpisode.embedId}`}
-          title={podcastEpisode.title}
-          frameBorder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-        ></iframe>
+        {podcastEpisode.embedId && (
+          <iframe
+            width="100%"
+            height="200"
+            src={`https://www.youtube.com/embed/${podcastEpisode.embedId}`}
+            title={podcastEpisode.title}
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          ></iframe>
+        )}
       </div>
       <div className="podcast-info">
         <h3 className="podcast-title">{podcastEpisode.title}</h3>
         <p className="podcast-description">{podcastEpisode.description}</p>
         <div className="podcast-links">
           <div className="platform-links">
-            <a href="#" className="platform-link youtube-link">
-              <FaYoutube /> Youtube
-            </a>
-            <a href="#" className="platform-link spotify-link">
-              <FaSpotify /> Spotify
-            </a>
+            {podcastEpisode.youtubeLink && (
+              <a href={podcastEpisode.youtubeLink} target="_blank" rel="noopener noreferrer" className="platform-link youtube-link">
+                <FaYoutube /> Youtube
+              </a>
+            )}
+            {podcastEpisode.spotifyLink && (
+              <a href={podcastEpisode.spotifyLink} target="_blank" rel="noopener noreferrer" className="platform-link spotify-link">
+                <FaSpotify /> Spotify
+              </a>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/podcast/podcastEpisodeList.tsx
+++ b/src/components/podcast/podcastEpisodeList.tsx
@@ -1,12 +1,11 @@
 import PodcastCard from 'components/podcast/podcastCard';
-import { useAllPodcastEpisodes } from 'hooks/usePodcast';
-import ErrorMessage from 'components/common/errorMessage';
-import Spinner from 'components/common/spinner';
+import { PodcastEpisode } from 'types/podcast';
 
-const PodcastEpisodesList = () => {
-  const { episodes, loading, error } = useAllPodcastEpisodes()
-  if (loading) return <Spinner />
-  if (error) return <ErrorMessage />
+type PodcastEpisodesListProps = {
+  episodes: PodcastEpisode[]
+}
+
+const PodcastEpisodesList = ({ episodes }: PodcastEpisodesListProps) => {
   return (
     <div className="episodes-grid">
       {episodes.map(episode => <PodcastCard key={episode.id} podcastEpisode={episode} />)}

--- a/src/hooks/useAsociacionInfo.ts
+++ b/src/hooks/useAsociacionInfo.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+import { asociacionInfoService } from "services/asociacionInfoService";
+import { AsociacionInfo } from "types/asociacionInfo";
+
+export function useAsociacionInfo() {
+  const [info, setInfo] = useState<AsociacionInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    asociacionInfoService.get()
+      .then(setInfo)
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return { info, loading, error }
+}

--- a/src/hooks/useBlogs.ts
+++ b/src/hooks/useBlogs.ts
@@ -1,48 +1,54 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { blogsService } from 'services/blogsService'
 import { Blog } from 'types/blog'
 import { BlogFilters } from 'types/filters'
 
+function matchesFilters(blog: Blog, filters?: BlogFilters): boolean {
+  if (!filters) return true
+  const { from, to, tagLabels, query, authorName } = filters
+
+  if (authorName && blog.author !== authorName) return false
+
+  if (query) {
+    const q = query.toLowerCase()
+    const hit = blog.title.toLowerCase().includes(q) || blog.author.toLowerCase().includes(q)
+    if (!hit) return false
+  }
+
+  if (tagLabels && tagLabels.length > 0) {
+    const blogTagLabels = blog.tags.map(t => t.label)
+    if (!tagLabels.some(label => blogTagLabels.includes(label))) return false
+  }
+
+  if (from && blog.date < from) return false
+  if (to && blog.date > to) return false
+
+  return true
+}
+
 export function useBlogs(filters?: BlogFilters) {
-  const [blogs, setBlogs] = useState<Blog[]>([])
+  const [allBlogs, setAllBlogs] = useState<Blog[]>([])
   const [recentBlogs, setRecentBlogs] = useState<Blog[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const hasFilters = filters && (
-    filters.tagLabels?.length ||
-    filters?.from ||
-    filters?.to ||
-    filters?.query ||
-    filters?.authorName
-  )
-
   useEffect(() => {
-    if (!hasFilters) {
-      Promise.all([blogsService.getAll(), blogsService.getRecentBlogs()])
-        .then(([all, recent]) => {
-          setBlogs(all)
-          setRecentBlogs(recent)
-        })
-        .catch(e => setError(e.message))
-        .finally(() => setLoading(false))
-      return
-    }
-
-    setLoading(true)
-    blogsService
-      .getFiltered({
-        from: filters.from || undefined,
-        to:   filters.to   || undefined,
-        tagLabels: filters.tagLabels?.length ? filters.tagLabels : undefined,
-        query: filters.query || undefined,
-        authorName: filters.authorName || undefined
+    blogsService.getAll()
+      .then(all => {
+        setAllBlogs(all)
+        const recent = [...all]
+          .sort((a, b) => (a.date < b.date ? 1 : -1))
+          .slice(0, 6)
+        setRecentBlogs(recent)
       })
-      .then(setBlogs)
       .catch(e => setError(e.message))
       .finally(() => setLoading(false))
+  }, [])
 
-  }, [filters?.from, filters?.to, filters?.tagLabels?.join(','), filters?.query, filters?.authorName])
+  const blogs = useMemo(
+    () => allBlogs.filter(blog => matchesFilters(blog, filters)),
+    [allBlogs, filters?.from, filters?.to, filters?.tagLabels?.join(','), filters?.query, filters?.authorName]
+  )
 
   return { blogs, recentBlogs, loading, error }
 }

--- a/src/hooks/useMembers.ts
+++ b/src/hooks/useMembers.ts
@@ -1,21 +1,28 @@
-import { useEffect, useState } from "react";
-import { membersService } from "services/membersService";
-import { Member } from "types/members";
+import { useEffect, useMemo, useState } from "react";
+import { membersService, AsociacionYear } from "services/membersService";
 
-export function useMembersByYear(year: string) {
-  const [members, setMembers] = useState<Member[]>([])
+export function useAsociaciones() {
+  const [entries, setEntries] = useState<AsociacionYear[]>([])
+  const [selectedYear, setSelectedYear] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    setLoading(true)
-    setError(null)
-    setMembers([])
-    membersService.getMembersByYear(year)
-      .then(setMembers)
+    membersService.getAll()
+      .then(data => {
+        const sorted = [...data].sort((a, b) => b.year - a.year)
+        setEntries(sorted)
+        if (sorted.length > 0) setSelectedYear(sorted[0].year)
+      })
       .catch(e => setError(e.message))
       .finally(() => setLoading(false))
-  }, [year])
-  
-  return { members, loading, error }
+  }, [])
+
+  const years = useMemo(() => entries.map(e => e.year), [entries])
+  const members = useMemo(
+    () => entries.find(e => e.year === selectedYear)?.members ?? [],
+    [entries, selectedYear]
+  )
+
+  return { years, selectedYear, setSelectedYear, members, loading, error }
 }

--- a/src/hooks/usePodcastCrew.ts
+++ b/src/hooks/usePodcastCrew.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+import { podcastCrewService } from "services/podcastCrewService";
+import { PodcastCrew } from "types/podcastCrew";
+
+export function usePodcastCrew() {
+  const [crew, setCrew] = useState<PodcastCrew | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    podcastCrewService.get()
+      .then(setCrew)
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return { crew, loading, error }
+}

--- a/src/pages/aboutUs/aboutus.css
+++ b/src/pages/aboutUs/aboutus.css
@@ -240,7 +240,15 @@
   font-size: 1.4rem;
   font-weight: 700;
   color: var(--font-color);
-  margin: 0 0 0.8rem 0;
+  margin: 0 0 0.2rem 0;
+}
+
+.member-cargo {
+  font-family: var(--font-subtitle);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--primary-color4);
+  margin: 0 0 0.6rem 0;
 }
 
 .member-description {

--- a/src/pages/aboutUs/aboutus.css
+++ b/src/pages/aboutUs/aboutus.css
@@ -239,7 +239,7 @@
   font-family: var(--font-subtitle);
   font-size: 1.4rem;
   font-weight: 700;
-  color: var(--primary-color1);
+  color: var(--font-color);
   margin: 0 0 0.8rem 0;
 }
 

--- a/src/pages/aboutUs/aboutus.tsx
+++ b/src/pages/aboutUs/aboutus.tsx
@@ -1,20 +1,22 @@
 import NavBar from '../../components/navbar/navbar';
 import './aboutus.css';
 import { useAsociaciones } from 'hooks/useMembers';
+import { useAsociacionInfo } from 'hooks/useAsociacionInfo';
 import { MemberCard } from 'components/members/memberCard';
 import ErrorMessage from 'components/common/errorMessage';
 import Spinner from 'components/common/spinner';
 
 const AboutUs = () => {
   const { years, selectedYear, setSelectedYear, members, loading, error } = useAsociaciones()
+  const { info: asociacionInfo } = useAsociacionInfo()
   const mostRecentYear = years[0]
 
   const associationInfo = {
     name: "AECCTI",
     subtitle1: "UNA ASOCIACIÓN",
     subtitle2: "DE ESTUDIANTES",
-    logo: null, // Se cargará de la DB
-    description: "Descripción de la asociación que se cargará desde la base de datos..."
+    description: asociacionInfo?.descripcion ?? "Descripción de la asociación que se cargará desde la base de datos...",
+    foto: asociacionInfo?.foto ?? null
   };
 
   return (
@@ -33,10 +35,13 @@ const AboutUs = () => {
                   <span className="estudiantes-text">ESTUDIANTES</span>
                 </div>
               </div>
-              {/* POSIBLE BUG EN EL FUTURO */}
-              <div className="logo-placeholder">
-                <span>Imagen Asociacion (bonitos y gorditos)</span>
-              </div>
+              {associationInfo.foto ? (
+                <img className="logo-placeholder" src={associationInfo.foto} alt={associationInfo.name} />
+              ) : (
+                <div className="logo-placeholder">
+                  <span>Imagen Asociacion (bonitos y gorditos)</span>
+                </div>
+              )}
             </div>
 
             <div className="hero-description">

--- a/src/pages/aboutUs/aboutus.tsx
+++ b/src/pages/aboutUs/aboutus.tsx
@@ -1,15 +1,13 @@
 import NavBar from '../../components/navbar/navbar';
-import { useState } from 'react';
 import './aboutus.css';
-import { useMembersByYear } from 'hooks/useMembers';
+import { useAsociaciones } from 'hooks/useMembers';
 import { MemberCard } from 'components/members/memberCard';
 import ErrorMessage from 'components/common/errorMessage';
 import Spinner from 'components/common/spinner';
 
 const AboutUs = () => {
-  const years = [2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012];
-  const [selectedYear, setSelectedYear] = useState(2025)
-  const { members, loading, error } = useMembersByYear(String(selectedYear))
+  const { years, selectedYear, setSelectedYear, members, loading, error } = useAsociaciones()
+  const mostRecentYear = years[0]
 
   const associationInfo = {
     name: "AECCTI",
@@ -65,7 +63,7 @@ const AboutUs = () => {
         {/* Members Section */}
         <section className="members-section">        
           <h2 className="members-title">
-            {selectedYear === 2025 ? 'MIEMBROS ACTUALES' : `MIEMBROS ${selectedYear}`}
+            {selectedYear === mostRecentYear ? 'MIEMBROS ACTUALES' : `MIEMBROS ${selectedYear}`}
           </h2>
 
           <div className="members-grid">

--- a/src/pages/podcast/podcast.tsx
+++ b/src/pages/podcast/podcast.tsx
@@ -1,5 +1,4 @@
 import NavBar from '../../components/navbar/navbar';
-import { useState } from 'react';
 import { FaYoutube, FaInstagram, FaTiktok } from 'react-icons/fa';
 import { FiFolder, FiSearch } from 'react-icons/fi';
 import './podcast.css';
@@ -7,26 +6,27 @@ import PodcastEpisodesList from 'components/podcast/podcastEpisodeList';
 import { usePodcastCrew } from 'hooks/usePodcastCrew';
 
 const Podcasts = () => {
-  const [activeTab, setActiveTab] = useState('TODAS');
   const { crew } = usePodcastCrew();
 
-  const playlistsData = [
-    {
-      id: 1,
-      title: "Los Favoritos",
-      description: "Los episodios más populares del podcast"
-    },
-    {
-      id: 2,
-      title: "Buscar trabajo", 
-      description: "Episodios sobre búsqueda de empleo y carrera"
-    },
-    {
-      id: 3,
-      title: "Noticias Tech",
-      description: "Las últimas noticias del mundo tecnológico"
-    }
-  ];
+  // TODO: re-enable playlists view in a future release.
+  // const [activeTab, setActiveTab] = useState('TODAS');
+  // const playlistsData = [
+  //   {
+  //     id: 1,
+  //     title: "Los Favoritos",
+  //     description: "Los episodios más populares del podcast"
+  //   },
+  //   {
+  //     id: 2,
+  //     title: "Buscar trabajo",
+  //     description: "Episodios sobre búsqueda de empleo y carrera"
+  //   },
+  //   {
+  //     id: 3,
+  //     title: "Noticias Tech",
+  //     description: "Las últimas noticias del mundo tecnológico"
+  //   }
+  // ];
 
   const socialLinks = [
     { 
@@ -46,7 +46,8 @@ const Podcasts = () => {
     }
   ];
 
-  const tabs = ['LISTAS', 'TODAS'];
+  // TODO: re-enable playlists view in a future release.
+  // const tabs = ['LISTAS', 'TODAS'];
 
   return (
     <main className='podcasts-content'>
@@ -91,11 +92,12 @@ const Podcasts = () => {
           </div>
         </section>
 
+        {/* TODO: re-enable playlists view in a future release.
         <section className="tabs-section">
           <div className="tabs-nav">
             {tabs.map((tab) => (
-              <button 
-                key={tab} 
+              <button
+                key={tab}
                 className={`tab-btn ${tab === activeTab ? 'active' : ''}`}
                 onClick={() => setActiveTab(tab)}
               >
@@ -104,6 +106,7 @@ const Podcasts = () => {
             ))}
           </div>
         </section>
+        */}
 
         <section className="publications-section">
           <div className="publications-container">
@@ -150,6 +153,7 @@ const Podcasts = () => {
               </div>
 
               <div className="podcasts-grid">
+                {/* TODO: re-enable playlists view in a future release.
                 {activeTab === 'LISTAS' ? (
                   <div className="playlists-grid">
                     {playlistsData.map((playlist) => (
@@ -168,6 +172,8 @@ const Podcasts = () => {
                 ) : (
                     <PodcastEpisodesList />
                   )}
+                */}
+                <PodcastEpisodesList />
               </div>
             </div>
           </div>

--- a/src/pages/podcast/podcast.tsx
+++ b/src/pages/podcast/podcast.tsx
@@ -1,12 +1,40 @@
 import NavBar from '../../components/navbar/navbar';
+import { useEffect, useMemo, useState } from 'react';
 import { FaYoutube, FaInstagram, FaTiktok } from 'react-icons/fa';
 import { FiFolder, FiSearch } from 'react-icons/fi';
 import './podcast.css';
 import PodcastEpisodesList from 'components/podcast/podcastEpisodeList';
 import { usePodcastCrew } from 'hooks/usePodcastCrew';
+import { useAllPodcastEpisodes } from 'hooks/usePodcast';
+import ErrorMessage from 'components/common/errorMessage';
+import Spinner from 'components/common/spinner';
 
 const Podcasts = () => {
   const { crew } = usePodcastCrew();
+  const { episodes, loading, error } = useAllPodcastEpisodes();
+
+  const years = useMemo(
+    () => Array.from(new Set(episodes.map(e => new Date(e.date).getFullYear()))).sort((a, b) => b - a),
+    [episodes]
+  );
+  const [selectedYears, setSelectedYears] = useState<number[]>([]);
+  const [yearsInitialized, setYearsInitialized] = useState(false);
+
+  useEffect(() => {
+    if (!yearsInitialized && years.length > 0) {
+      setSelectedYears(years);
+      setYearsInitialized(true);
+    }
+  }, [years, yearsInitialized]);
+
+  const toggleYear = (year: number) => {
+    setSelectedYears(prev => prev.includes(year) ? prev.filter(y => y !== year) : [...prev, year]);
+  };
+
+  const yearFilteredEpisodes = useMemo(
+    () => episodes.filter(e => selectedYears.includes(new Date(e.date).getFullYear())),
+    [episodes, selectedYears]
+  );
 
   // TODO: re-enable playlists view in a future release.
   // const [activeTab, setActiveTab] = useState('TODAS');
@@ -118,26 +146,16 @@ const Podcasts = () => {
                 Publicaciones
               </h3>
               <div className="year-filters">
-                <label className="year-filter">
-                  <input type="checkbox" defaultChecked />
-                  <span>2017</span>
-                </label>
-                <label className="year-filter">
-                  <input type="checkbox" defaultChecked />
-                  <span>2018</span>
-                </label>
-                <label className="year-filter">
-                  <input type="checkbox" />
-                  <span>2019</span>
-                </label>
-                <label className="year-filter">
-                  <input type="checkbox" />
-                  <span>2020</span>
-                </label>
-                <label className="year-filter">
-                  <input type="checkbox" />
-                  <span>2021</span>
-                </label>
+                {years.map(year => (
+                  <label key={year} className="year-filter">
+                    <input
+                      type="checkbox"
+                      checked={selectedYears.includes(year)}
+                      onChange={() => toggleYear(year)}
+                    />
+                    <span>{year}</span>
+                  </label>
+                ))}
               </div>
             </div>
 
@@ -175,7 +193,12 @@ const Podcasts = () => {
                     <PodcastEpisodesList />
                   )}
                 */}
-                <PodcastEpisodesList />
+                {loading
+                  ? <Spinner />
+                  : error
+                    ? <ErrorMessage />
+                    : <PodcastEpisodesList episodes={yearFilteredEpisodes} />
+                }
               </div>
             </div>
           </div>

--- a/src/pages/podcast/podcast.tsx
+++ b/src/pages/podcast/podcast.tsx
@@ -31,10 +31,14 @@ const Podcasts = () => {
     setSelectedYears(prev => prev.includes(year) ? prev.filter(y => y !== year) : [...prev, year]);
   };
 
-  const yearFilteredEpisodes = useMemo(
-    () => episodes.filter(e => selectedYears.includes(new Date(e.date).getFullYear())),
-    [episodes, selectedYears]
-  );
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const visibleEpisodes = useMemo(() => {
+    const byYear = episodes.filter(e => selectedYears.includes(new Date(e.date).getFullYear()));
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return byYear;
+    return byYear.filter(e => e.title.toLowerCase().includes(q));
+  }, [episodes, selectedYears, searchQuery]);
 
   // TODO: re-enable playlists view in a future release.
   // const [activeTab, setActiveTab] = useState('TODAS');
@@ -163,13 +167,15 @@ const Podcasts = () => {
               <div className="search-bar">
                 <div className="search-input-wrapper">
                   <FiSearch className="search-icon" />
-                  <input 
-                    type="text" 
-                    placeholder="Buscar..." 
+                  <input
+                    type="text"
+                    placeholder="Buscar..."
                     className="search-input"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
                   />
                 </div>
-                <span className="post-count">(3 posts)</span>
+                <span className="post-count">({visibleEpisodes.length} posts)</span>
               </div>
 
               <div className="podcasts-grid">
@@ -197,7 +203,7 @@ const Podcasts = () => {
                   ? <Spinner />
                   : error
                     ? <ErrorMessage />
-                    : <PodcastEpisodesList episodes={yearFilteredEpisodes} />
+                    : <PodcastEpisodesList episodes={visibleEpisodes} />
                 }
               </div>
             </div>

--- a/src/pages/podcast/podcast.tsx
+++ b/src/pages/podcast/podcast.tsx
@@ -55,11 +55,13 @@ const Podcasts = () => {
       <div className="podcasts-page">
         <section className="hero-section-podcasts">
           <div className="hero-overlay">
-            <img 
-              src="https://media.istockphoto.com/id/2242721518/photo/modern-podcast-studio-with-two-armchairs-microphones-and-soft-lighting-setup.jpg?s=2048x2048&w=is&k=20&c=utXkzAsCPRfWqPsPDEq40-HIQsnR3M3_ZdcBOtay8to=" 
-              alt="Podcast Image"
-              className="hero-background"
-            />
+            {crew?.heroImage && (
+              <img
+                src={crew.heroImage}
+                alt="Podcast Image"
+                className="hero-background"
+              />
+            )}
           </div>
         </section>
 

--- a/src/pages/podcast/podcast.tsx
+++ b/src/pages/podcast/podcast.tsx
@@ -4,9 +4,11 @@ import { FaYoutube, FaInstagram, FaTiktok } from 'react-icons/fa';
 import { FiFolder, FiSearch } from 'react-icons/fi';
 import './podcast.css';
 import PodcastEpisodesList from 'components/podcast/podcastEpisodeList';
+import { usePodcastCrew } from 'hooks/usePodcastCrew';
 
 const Podcasts = () => {
   const [activeTab, setActiveTab] = useState('TODAS');
+  const { crew } = usePodcastCrew();
 
   const playlistsData = [
     {
@@ -65,11 +67,7 @@ const Podcasts = () => {
             <div className="about-content">
               <h2 className="about-title">¿QUIÉNES SOMOS?</h2>
               <p className="about-description">
-                Since My Favorite Murder launched in January of 2016, Karen 
-                Kilgariff and Georgia Hardstark have shared their lifelong 
-                interest in true crime stories and have covered infamous serial 
-                killers, mysterious cold cases, captivating cults, incredible 
-                survivor stories and important events from history.
+                {crew?.proposito ?? 'Cargando...'}
               </p>
               <div className="social-links">
                 {socialLinks.map((social, index) => (

--- a/src/pages/tags/tags.css
+++ b/src/pages/tags/tags.css
@@ -38,6 +38,7 @@ h2 {
 .confirm-btn {
   font-family: var(--font-title);
   font-size: 1rem;
+  line-height: 1;
   color: var(--font-color);
   background: none;
   border: 2px solid var(--font-color);

--- a/src/pages/tags/tags.css
+++ b/src/pages/tags/tags.css
@@ -36,10 +36,11 @@ h2 {
 }
 
 .confirm-btn {
+  font-family: var(--font-title);
   font-size: 1rem;
   color: var(--font-color);
   background: none;
-  border: var(--font-color) 1px solid;
+  border: 2px solid var(--font-color);
   cursor: pointer;
   padding: 0.6rem 1.25rem;
   border-radius: 4px;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,4 @@
-const BASE_URL = process.env.REACT_APP_STRAPI_URL
+export const BASE_URL = process.env.REACT_APP_STRAPI_URL
 const TOKEN = process.env.REACT_APP_STRAPI_TOKEN
 
 async function request(method: string, path: string, body: unknown = null) {

--- a/src/services/asociacionInfoService.ts
+++ b/src/services/asociacionInfoService.ts
@@ -1,0 +1,14 @@
+import { AsociacionInfo } from "types/asociacionInfo";
+import { api, BASE_URL } from "./api";
+
+export const asociacionInfoService = {
+  get: async (): Promise<AsociacionInfo | null> => {
+    const data = await api.get('asociacion-infos?populate=*&pagination[pageSize]=1');
+    const item = data.data[0];
+    if (!item) return null;
+    return {
+      descripcion: item.descripcion,
+      foto: item.foto?.url ? `${BASE_URL}${item.foto.url}` : null
+    };
+  }
+}

--- a/src/services/blogsService.ts
+++ b/src/services/blogsService.ts
@@ -1,7 +1,6 @@
 import { Blog } from "types/blog"
 import { api } from "./api"
 import { mapTag } from "./tagsService"
-import { BlogFilters } from "types/filters"
 
 const mapBlog = (item: any): Blog => {
   const imagenUrl = item.imagenes?.[0]?.url;
@@ -19,74 +18,6 @@ const mapBlog = (item: any): Blog => {
   }
 }
 
-function buildQuery(filters: BlogFilters): string {
-  const params = new URLSearchParams()
-  params.set('populate', '*')
-
-  const { from, to, tagLabels, query, authorName } = filters
-  const hasDates = from || to
-  const hasTags  = tagLabels && tagLabels.length > 0
-  const hasSearch = query && query.length > 0
-  const hasAuthor = !!authorName
-
-  if (hasAuthor) {
-    params.set('filters[author_profile][nombre][$eq]', authorName!)
-  }
-
-  if (hasSearch) {
-    params.set('filters[$or][0][Titulo][$containsi]', query)
-    params.set('filters[$or][1][author_profile][nombre][$containsi]', query)
-  }
-
-  if (hasDates && !hasTags) {
-    if (from) params.set('filters[fecha_de_publicacion][$gte]', from)
-    if (to)   params.set('filters[fecha_de_publicacion][$lte]', to)
-  }
-
-  if (hasTags && !hasDates) {
-    tagLabels.forEach((label, i) =>
-      params.set(`filters[$or][${i}][tags][$eq]`, label)
-    )
-  }
-
-  if (hasDates && hasTags) {
-    tagLabels.forEach((label, i) =>
-      params.set(`filters[$and][0][$or][${i}][tags][$eq]`, label)
-    )
-    if (from) params.set('filters[$and][1][fecha_de_publicacion][$gte]', from)
-    if (to)   params.set('filters[$and][1][fecha_de_publicacion][$lte]', to)
-  }
-
-  if ((hasDates || hasTags) && hasSearch) {
-    params.set('filters[$and][0][$or][0][Titulo][$containsi]', query)
-    params.set('filters[$and][0][$or][1][author_profile][nombre][$containsi]', query)
-
-    let andIndex = 1
-
-    if (hasTags) {
-      tagLabels.forEach((tag, i) =>
-        params.set(`filters[$and][${andIndex}][$or][${i}][tagLabels][$eq]`, tag)
-      )
-      andIndex++
-    }
-
-    if (hasDates) {
-      if (from) params.set(`filters[$and][${andIndex}][fecha_de_publicacion][$gte]`, from)
-      if (to)   params.set(`filters[$and][${andIndex}][fecha_de_publicacion][$lte]`, to)
-    }
-  }
-
-  if (hasDates && hasTags && !hasSearch) {
-    tagLabels.forEach((tag, i) =>
-      params.set(`filters[$and][0][$or][${i}][tagLabels][$eq]`, tag)
-    )
-    if (from) params.set('filters[$and][1][fecha_de_publicacion][$gte]', from)
-    if (to)   params.set('filters[$and][1][fecha_de_publicacion][$lte]', to)
-  }
-
-  return params.toString()
-}
-
 export const blogsService = {
   getAll: async (): Promise<Blog[]> => {
     const data = await api.get('article-mds?populate=*')
@@ -94,15 +25,6 @@ export const blogsService = {
   },
   getNews: async (): Promise<Blog[]> => {
     const data = await api.get('article-mds/news?populate=*')
-    return data.data.map(mapBlog)
-  },
-  getRecentBlogs: async (): Promise<Blog[]> => {
-    const data = await api.get('article-mds?sort[0]=fecha_de_publicacion:desc&pagination[page]=1&pagination[pageSize]=6&populate=*')
-    return data.data.map(mapBlog)
-  },
-  getFiltered: async (filters: BlogFilters): Promise<Blog[]> => {
-    const qs = buildQuery(filters)
-    const data = await api.get(`article-mds?${qs}`)
     return data.data.map(mapBlog)
   },
   getBlogByID: async (id: number): Promise<Blog> => {

--- a/src/services/membersService.ts
+++ b/src/services/membersService.ts
@@ -11,7 +11,8 @@ const mapMember = (item: any): Member => {
     id: item.id,
     name: item.nombre,
     image: item.foto?.url,
-    description: item.curriculum
+    description: item.curriculum,
+    cargo: item.Cargo ?? null
   }
 }
 

--- a/src/services/membersService.ts
+++ b/src/services/membersService.ts
@@ -1,6 +1,11 @@
 import { Member } from "types/members";
 import { api } from "./api";
 
+export interface AsociacionYear {
+  year: number;
+  members: Member[];
+}
+
 const mapMember = (item: any): Member => {
   return {
     id: item.id,
@@ -11,8 +16,11 @@ const mapMember = (item: any): Member => {
 }
 
 export const membersService = {
-  getMembersByYear: async(year: string): Promise<Member[]> => {
-    const data = await api.get(`asociaciones?filters[year][$eq]=${year}&populate[Miembro][populate][foto][fields][0]=url`);
-    return data.data[0].Miembro.map((item: any) => mapMember(item))
+  getAll: async (): Promise<AsociacionYear[]> => {
+    const data = await api.get('asociaciones?populate[Miembro][populate][foto][fields][0]=url');
+    return data.data.map((item: any) => ({
+      year: item.year,
+      members: (item.Miembro ?? []).map(mapMember)
+    }));
   }
 }

--- a/src/services/podcastCrewService.ts
+++ b/src/services/podcastCrewService.ts
@@ -1,0 +1,15 @@
+import { PodcastCrew } from "types/podcastCrew";
+import { api, BASE_URL } from "./api";
+
+export const podcastCrewService = {
+  get: async (): Promise<PodcastCrew | null> => {
+    const data = await api.get('podcast-crew?populate=*');
+    const item = data.data;
+    if (!item) return null;
+    return {
+      nombre: item.nombre,
+      proposito: item.proposito,
+      heroImage: item.hero_image?.url ? `${BASE_URL}${item.hero_image.url}` : null
+    };
+  }
+}

--- a/src/services/podcastService.ts
+++ b/src/services/podcastService.ts
@@ -7,7 +7,7 @@ const getYoutubeEmbedId = (url: string): string => {
 }
 
 const mapPodcastEpisode = (item: any): PodcastEpisode => {
-  const embedId = getYoutubeEmbedId(item.link)
+  const embedId = item.youtube_link ? getYoutubeEmbedId(item.youtube_link) : ''
   return {
     id: item.id,
     title: item.title,
@@ -15,7 +15,9 @@ const mapPodcastEpisode = (item: any): PodcastEpisode => {
     embedId,
     category: item.category ?? '',
     date: item.date_publication,
-    thumbnail: `https://img.youtube.com/vi/${embedId}/hqdefault.jpg`
+    thumbnail: `https://img.youtube.com/vi/${embedId}/hqdefault.jpg`,
+    spotifyLink: item.link ?? null,
+    youtubeLink: item.youtube_link ?? null
   }
 }
 

--- a/src/services/tagsService.ts
+++ b/src/services/tagsService.ts
@@ -9,7 +9,13 @@ export const mapTag = (raw: string, index: number): Tag => ({
 
 export const tagsService = {
   getAllTags: async (): Promise<Tag[]> => {
-    const data = await api.get('article-mds/unique-tags');
-    return data.data.map((label: string, index: number) => mapTag(label, index));
+    // article-mds/unique-tags isn't merged on the backend yet, so derive the
+    // distinct tags in use from a lightweight fetch (tags field only)
+    // instead of depending on it.
+    const data = await api.get('article-mds?fields[0]=tags&pagination[pageSize]=100');
+    const labels = Array.from(
+      new Set(data.data.map((item: any) => item.tags).filter((t: string | null) => !!t))
+    ) as string[];
+    return labels.map((label, index) => mapTag(label, index));
   }
 }

--- a/src/types/asociacionInfo.ts
+++ b/src/types/asociacionInfo.ts
@@ -1,0 +1,4 @@
+export interface AsociacionInfo {
+  descripcion: string;
+  foto: string | null;
+}

--- a/src/types/members.ts
+++ b/src/types/members.ts
@@ -3,4 +3,5 @@ export interface Member {
   name: string
   image: string | null
   description: string
+  cargo: string | null
 }

--- a/src/types/podcast.ts
+++ b/src/types/podcast.ts
@@ -6,4 +6,6 @@ export interface PodcastEpisode {
   category: string
   date: string
   thumbnail: string
+  spotifyLink: string | null
+  youtubeLink: string | null
 }

--- a/src/types/podcastCrew.ts
+++ b/src/types/podcastCrew.ts
@@ -1,0 +1,5 @@
+export interface PodcastCrew {
+  nombre: string;
+  proposito: string;
+  heroImage: string | null;
+}


### PR DESCRIPTION
## Summary
A batch of fixes across the Asociación, Podcast, and Blog pages found while clicking through the live app against a running backend:

- **navbar**: global b/p/n keyboard shortcuts fired even while typing in a search box (typing "n" redirected to /aboutus mid-search). Now ignored while an input/textarea/contenteditable is focused.
- **blogs**: fetch once and filter client-side instead of re-hitting the API on every filter/search change.
- **aboutus**: year tabs were a hardcoded list (up to 2025 only) that re-fetched per year click; now fetched once and derived client-side. Photo/description now served from the new `asociacion-info` endpoint (needs backend PR #13). Member cards now show their `Cargo` as a subtitle. Fixed member name and date-picker text/icon colors not adapting to light/dark theme.
- **tags**: the tag filter was permanently empty because it depended on a backend endpoint that was never merged (`article-mds/unique-tags`); now derives tags from a lightweight article fetch instead. Fixed button font/border/padding to match the site's conventions.
- **podcast**: "Quiénes somos" text and hero background image now come from `podcast-crew` (needs backend PR #13) instead of being hardcoded. Removed the non-functional "Listas" tab (commented out with a TODO for a future release). Added a YouTube link alongside the existing Spotify link (needs backend PR #13). Fixed the year-publication filter checkboxes and search box, neither of which were wired to any state before.
- **landing**: cave title used a dark orange in light mode; now matches the outermost cave layer's own light-mode fill color.

## Depends on
Backend PR #13 (asociacion-info, podcast-crew hero_image, podcast youtube_link) - some of the features above degrade gracefully without it (fields just render empty/hidden) but won't show real data until it's merged.

## Test plan
- [x] `npm start` against a local backend with PR #13's changes applied; clicked through /aboutus, /podcast, /blogs, /tags
- [x] Confirmed filter/search interactions on /blogs and /podcast don't trigger additional API calls after the initial load